### PR TITLE
Add url in body of oob messages

### DIFF
--- a/src/services/XmppClient.js
+++ b/src/services/XmppClient.js
@@ -321,7 +321,7 @@ class XmppClient {
       },
       xml(
         'body', {},
-        url ? null : body,
+        url ? url : body,
       ),
       hasChatState ? xml('active', { xmlns: NS.CHAT_STATE }) : null,
       url ? xml(


### PR DESCRIPTION
This is an attempt at fixing http uploading images sent as OOB messages. I'm submitting this because I noticed multiple clients aren't displaying images when sent from xmpp-web.

https://docs.modernxmpp.org/client/protocol/#communicating-the-url

I have to admit I haven't tested this change but it seems rather straightfoward. This does means that a body can't be provided alongside a URL.

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>