### PR TITLE
prevent user from sending empty messages

### DIFF
--- a/src/components/Sendbox.vue
+++ b/src/components/Sendbox.vue
@@ -79,6 +79,10 @@ export default {
           await this.postFile(this.file)
           return
         }
+        if (this.composingMessage.trim() === '') {
+          // do not send empty messages
+          return
+        }
         await this.$xmpp.sendMessage(this.activeChat, this.composingMessage, this.isRoom)
         this.composingMessage = ''
       } catch (error) {


### PR DESCRIPTION
Currently, if `hasSendingEnterKey` is enabled, it is possible to mistakenly send an empty message or spam the room with empty messages simply by keeping <kbd>Enter</kbd> pressed. This PR prevents sending a message, when the input is empty.