### PR TITLE
feat: send authorization for file uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 node_modules
 /dist
 
-public/local.js
-
 # local env files
 .env.local
 .env.*.local

--- a/public/local.js
+++ b/public/local.js
@@ -2,7 +2,7 @@
 var config = {
   name: 'XMPP web',
   transports: {
-    websocket: 'wss://xmpp.kittycob.dev:5281/xmpp-websocket',
+    websocket: 'wss://chat.domain-web.ltd/xmpp-websocket',
   },
   hasGuestAccess: true,
   hasRegisteredAccess: true,
@@ -11,7 +11,7 @@ var config = {
   isTransportsUserAllowed: false,
   hasHttpAutoDiscovery: false,
   resource: 'Web XMPP',
-  defaultDomain: 'xmpp.kittycob.dev',
+  defaultDomain: 'domain-xmpp.ltd',
   defaultMuc: null,
   // defaultMuc: 'conference.domain-xmpp.ltd',
   isStylingDisabled: false,


### PR DESCRIPTION
I encountered the same issue as #128 #141, figured out that prosody file upload servers send along an authorization token which is required in the PUT request that uploads the file. This PR fixes this issue by including the authorization token as a header if it is found in the original response.