### PR TITLE
ci: fix TLS settings for e2e testing

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -41,3 +41,5 @@ jobs:
           config: baseUrl=https://localhost:3000/
           start: pnpm run dev
           wait-on: 'https://localhost:3000'
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: 0


### PR DESCRIPTION
Set NODE_TLS_REJECT_UNAUTHORIZED to 0 for e2e tests.